### PR TITLE
Update compat entry for ChunkSplitters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-ChunkSplitters = "^0.1, 1.0"
+ChunkSplitters = "^0.1, 1.0, 2.0"
 DelaunayTriangulation = "0.7"
 DiffEqBase = "^6.0"
 FunctionWrappersWrappers = "^0.1"


### PR DESCRIPTION
We released a formally breaking version of ChunkSplitters (v2.0.0), but which does not affect most users. It won´t affect your package, so here I'm proposing the update of the compat entry to accept the 2.0 version.