### PR TITLE
Spellcheck: fix typos / extend allowlist

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,4 +1,6 @@
 [default.extend-words]
+# Math subscript in LaTeX (m_{iy} = y-component of midpoint m_i) in docs/src/math.md
+iy = "iy"
 # Julia-specific functions
 indexin = "indexin"
 findfirst = "findfirst"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,7 +28,7 @@ if RUN_EXAMPLES
         )
         return content
     end
-    # We can add the code to the end of each file in its uncommented form programatically.
+    # We can add the code to the end of each file in its uncommented form programmatically.
     function add_just_the_code_section(dir, file)
         file_name, file_ext = splitext(file)
         file_path = joinpath(dir, file)

--- a/docs/src/literate_tutorials/laplaces_equation_with_internal_dirichlet_conditions.jl
+++ b/docs/src/literate_tutorials/laplaces_equation_with_internal_dirichlet_conditions.jl
@@ -59,7 +59,7 @@ BCs = BoundaryConditions(mesh, bcs, types)
 # This is done using `InternalConditions`. First,
 # we need to find all the vertices that lie on
 # the line $\{x = 1/2, 0 \leq y \leq 2/5\}$. We could
-# compute these manually, but let's find them programatically
+# compute these manually, but let's find them programmatically
 # instead for the sake of demonstration.
 function find_all_points_on_line(tri)
     vertices = Int[]

--- a/docs/src/literate_tutorials/piecewise_linear_and_natural_neighbour_interpolation_for_an_advection_diffusion_equation.jl
+++ b/docs/src/literate_tutorials/piecewise_linear_and_natural_neighbour_interpolation_for_an_advection_diffusion_equation.jl
@@ -1,6 +1,6 @@
 using DisplayAs #hide
 tc = DisplayAs.withcontext(:displaysize => (15, 80), :limit => true); #hide
-# # Piecewise Linear and Natural Neighbour Inteprolation for an Advection-Diffusion Equation
+# # Piecewise Linear and Natural Neighbour Interpolation for an Advection-Diffusion Equation
 # In this tutorial, we have three aims:
 #
 # 1. Demonstrate how to solve an advection-diffusion equation.
@@ -243,7 +243,7 @@ fig
 ) fig #src
 
 # ## Natural neighbour interpolation
-# Since the solution is defined over a triangulation, the most natural form of inteprolation to use,
+# Since the solution is defined over a triangulation, the most natural form of interpolation to use,
 # other than piecewise linear interpolation, is natural neighbour interpolation. We can use
 # [NaturalNeighbours.jl](https://github.com/DanielVandH/NaturalNeighbours.jl) for this;
 # NaturalNeighbours.jl also provides the same piecewise linear interpolant above via its

--- a/docs/src/literate_tutorials/porous_fisher_equation_and_travelling_waves.jl
+++ b/docs/src/literate_tutorials/porous_fisher_equation_and_travelling_waves.jl
@@ -38,7 +38,7 @@ tc = DisplayAs.withcontext(:displaysize => (15, 80), :limit => true); #hide
 # \end{equation}
 # ```
 # where $c_{\min} = \sqrt{\lambda/(2D)}$, $c = \sqrt{D\lambda/2}$, and $z = x-ct$ is the
-# travelling wave coordinates. This travelling wave would mathc our problem exactly
+# travelling wave coordinates. This travelling wave would match our problem exactly
 # if the rectangle were instead $[0, a] \times \mathbb R$, but by choosing $b$ large
 # enough we can at least emulate the travelling wave behaviour closely; the
 # homogeneous Neumann conditions are to ensure no energy is lost, thus allowing the travelling

--- a/docs/src/literate_wyos/diffusion_equations.jl
+++ b/docs/src/literate_wyos/diffusion_equations.jl
@@ -176,7 +176,7 @@ function boundary_edge_contributions!(
 end
 
 # Now that we have the parts for handling the main flux contributions, we need to consider
-# the boundary conditions. Note that in the code above we have alredy taken not to update
+# the boundary conditions. Note that in the code above we have already taken not to update
 # $\vb A$ or $\vb b$ if there a boundary condition at the associated node, so we do not
 # need to worry about e.g. zeroing out rows of $\vb A$ for a node with a boundary condition.
 function apply_dirichlet_conditions!(initial_condition, mesh, conditions)

--- a/docs/src/literate_wyos/linear_reaction_diffusion_equations.jl
+++ b/docs/src/literate_wyos/linear_reaction_diffusion_equations.jl
@@ -14,7 +14,7 @@ tc = DisplayAs.withcontext(:displaysize => (15, 80), :limit => true); #hide
 # ```
 # We want to turn this into an equation of the form $\mathrm d\vb u/\mathrm dt = \vb A\vb u + \vb b$
 # as usual. This takes the same form as our [diffusion equation example](diffusion_equations.md),
-# except with the extra $f(\vb x)u$ term, which just adds an exta $f(\vb x)$ term
+# except with the extra $f(\vb x)u$ term, which just adds an extra $f(\vb x)$ term
 # to the diagonal of $\vb A$. See the previois sections for further mathematical details.
 
 # ## Implementation

--- a/docs/src/literate_wyos/poissons_equation.jl
+++ b/docs/src/literate_wyos/poissons_equation.jl
@@ -312,7 +312,7 @@ E |> tc #hide
 # For plotting the electric field, we will show the electric field intensity $\|\vb E\|$,
 # and we can also show the arrows. Rather than showing all arrows, we will show them at
 # a smaller grid of values, which requires differentiating `itp` so that we can get the
-# gradients at arbitary points.
+# gradients at arbitrary points.
 ∂ = differentiate(itp, 1)
 x = LinRange(0, 10, 25)
 y = LinRange(0, 10, 25)

--- a/docs/src/tutorials/laplaces_equation_with_internal_dirichlet_conditions.md
+++ b/docs/src/tutorials/laplaces_equation_with_internal_dirichlet_conditions.md
@@ -82,7 +82,7 @@ We now need to define the internal conditions.
 This is done using `InternalConditions`. First,
 we need to find all the vertices that lie on
 the line $\{x = 1/2, 0 \leq y \leq 2/5\}$. We could
-compute these manually, but let's find them programatically
+compute these manually, but let's find them programmatically
 instead for the sake of demonstration.
 
 ````@example laplaces_equation_with_internal_dirichlet_conditions

--- a/docs/src/tutorials/piecewise_linear_and_natural_neighbour_interpolation_for_an_advection_diffusion_equation.md
+++ b/docs/src/tutorials/piecewise_linear_and_natural_neighbour_interpolation_for_an_advection_diffusion_equation.md
@@ -8,7 +8,7 @@ tc = DisplayAs.withcontext(:displaysize => (15, 80), :limit => true); #hide
 nothing #hide
 ````
 
-# Piecewise Linear and Natural Neighbour Inteprolation for an Advection-Diffusion Equation
+# Piecewise Linear and Natural Neighbour Interpolation for an Advection-Diffusion Equation
 
 In this tutorial, we have three aims:
 
@@ -210,7 +210,7 @@ fig
 
 ## Natural neighbour interpolation
 
-Since the solution is defined over a triangulation, the most natural form of inteprolation to use,
+Since the solution is defined over a triangulation, the most natural form of interpolation to use,
 other than piecewise linear interpolation, is natural neighbour interpolation. We can use
 [NaturalNeighbours.jl](https://github.com/DanielVandH/NaturalNeighbours.jl) for this;
 NaturalNeighbours.jl also provides the same piecewise linear interpolant above via its

--- a/docs/src/tutorials/porous_fisher_equation_and_travelling_waves.md
+++ b/docs/src/tutorials/porous_fisher_equation_and_travelling_waves.md
@@ -53,7 +53,7 @@ u(y, t) = \begin{cases} 1-\mathrm{e}^{c_{\min}z} & z \leq 0, \\ 0 & z > 0, \end{
 ```
 
 where $c_{\min} = \sqrt{\lambda/(2D)}$, $c = \sqrt{D\lambda/2}$, and $z = x-ct$ is the
-travelling wave coordinates. This travelling wave would mathc our problem exactly
+travelling wave coordinates. This travelling wave would match our problem exactly
 if the rectangle were instead $[0, a] \times \mathbb R$, but by choosing $b$ large
 enough we can at least emulate the travelling wave behaviour closely; the
 homogeneous Neumann conditions are to ensure no energy is lost, thus allowing the travelling

--- a/docs/src/wyos/diffusion_equations.md
+++ b/docs/src/wyos/diffusion_equations.md
@@ -198,7 +198,7 @@ end
 ````
 
 Now that we have the parts for handling the main flux contributions, we need to consider
-the boundary conditions. Note that in the code above we have alredy taken not to update
+the boundary conditions. Note that in the code above we have already taken not to update
 $\vb A$ or $\vb b$ if there a boundary condition at the associated node, so we do not
 need to worry about e.g. zeroing out rows of $\vb A$ for a node with a boundary condition.
 

--- a/docs/src/wyos/linear_reaction_diffusion_equations.md
+++ b/docs/src/wyos/linear_reaction_diffusion_equations.md
@@ -27,7 +27,7 @@ To start, let's give the mathematical details. The problems we will be solving t
 
 We want to turn this into an equation of the form $\mathrm d\vb u/\mathrm dt = \vb A\vb u + \vb b$
 as usual. This takes the same form as our [diffusion equation example](diffusion_equations.md),
-except with the extra $f(\vb x)u$ term, which just adds an exta $f(\vb x)$ term
+except with the extra $f(\vb x)u$ term, which just adds an extra $f(\vb x)$ term
 to the diagonal of $\vb A$. See the previois sections for further mathematical details.
 
 ## Implementation

--- a/docs/src/wyos/poissons_equation.md
+++ b/docs/src/wyos/poissons_equation.md
@@ -356,7 +356,7 @@ E |> tc #hide
 For plotting the electric field, we will show the electric field intensity $\|\vb E\|$,
 and we can also show the arrows. Rather than showing all arrows, we will show them at
 a smaller grid of values, which requires differentiating `itp` so that we can get the
-gradients at arbitary points.
+gradients at arbitrary points.
 
 ````@example poissons_equation
 ∂ = differentiate(itp, 1)

--- a/src/specific_problems/mean_exit_time.jl
+++ b/src/specific_problems/mean_exit_time.jl
@@ -26,7 +26,7 @@ You can solve this problem using [`solve`](@ref solve(::AbstractFVMTemplate, arg
 - `ICs::InternalConditions=InternalConditions()`: The [`InternalConditions`](@ref).
 
 The functions for `BCs` and `ICs` are not used. Whenever a [`Neumann`](@ref) condition is encountered, 
-or a [`Dirichlet`](@ref) condition, it is assumed that the conditon is homogeneous. If any of the 
+or a [`Dirichlet`](@ref) condition, it is assumed that the condition is homogeneous. If any of the 
 conditions are [`Dudt`](@ref) or [`Constrained`](@ref) types, then an error is thrown.
 
 ## Keyword Arguments


### PR DESCRIPTION
Fixes the failing **Spell Check** (`crate-ci/typos@v1.47.0`) CI.

Reproduced locally with `typos` 1.47.0 (same version CI uses). Findings and dispositions:

Real prose/comment typos fixed (in both the Literate `.jl` sources and the generated `.md`, plus one source docstring):
- `programatically` -> `programmatically`
- `Inteprolation`/`inteprolation` -> `Interpolation`/`interpolation`
- `alredy` -> `already`
- `arbitary` -> `arbitrary`
- `mathc` -> `match`
- `exta` -> `extra`
- `conditon` -> `condition` (`src/specific_problems/mean_exit_time.jl` docstring)

False positive allowlisted in `.typos.toml`:
- `iy` — LaTeX math subscript `m_{iy}` (y-component of midpoint) in `docs/src/math.md`, not a typo.

`typos` now exits 0 with zero findings.

Ignore until reviewed by @ChrisRackauckas.