### PR TITLE
Downgrade: raise SciMLBase compat floor to 2.34

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ CommonSolve = "0.2"
 DelaunayTriangulation = "1.0"
 PreallocationTools = "0.4, 1.2"
 PrecompileTools = "1.2"
-SciMLBase = "2, 3.1"
+SciMLBase = "2.34, 3.1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
## Fix MINIMUM-VERSION downgrade resolve failure

The `Downgrade` workflow fails (latest failing run [27462277554](https://github.com/SciML/FiniteVolumeMethod.jl/actions/runs/27462277554)) with:

```
empty intersection between ADTypes@0.2.7 and project compatibility 1.1.0-1
```

### Conflicting pin / why the old floor was impossible

At the downgrade minimum the resolver pins the root dep `SciMLBase` to its **2.0** floor. SciMLBase 2.0.x declares `ADTypes = "0.1.3-0.2"`, so the downgrade manifest pins **ADTypes 0.2.7**. The test environment (`test/Project.toml`) declares `ADTypes = "1.1"`, so the subsequent `Pkg.test` re-resolve sees ADTypes 0.2.7 against the test compat `1.1.0-1` → empty intersection.

SciMLBase only began admitting `ADTypes` 1.x at **2.34.0** (compat `["0.2.5-0.2", "1"]`); every SciMLBase `< 2.34.0` is restricted to ADTypes `0.2.x`. So the old floor `SciMLBase = "2, 3.1"` was never co-installable with the package's own modern test stack (which requires ADTypes `>= 1.1`).

### Fix

Raise the `SciMLBase` floor to **2.34** (`SciMLBase = "2.34, 3.1"`) — the first SciMLBase release that admits ADTypes 1.x. Lower-bound raise only; the upper structure (`3.1`) and all test logic are unchanged.

### Resolve verification (local, Julia 1.10 lts floor, Resolver.jl `--min=@deps`)

- old floor `SciMLBase = "2, 3.1"` → manifest pins SciMLBase 2.0.x, **ADTypes 0.2.7** → reproduces the empty-intersection against the test ADTypes `1.1` floor
- new floor `SciMLBase = "2.34, 3.1"` → manifest pins SciMLBase 2.34.0, **ADTypes 1.22.0** (∈ test compat `1.1`) → conflict eliminated

Note: the package's regular (latest-versions) `Tests` failure on `main` is a separate, unrelated issue (JET 0.11.x requiring a newer Julia on `lts`, plus a SparseDiffTools/SciMLOperators conflict), not addressed here.

---
This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
