### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ meshgeometry.geo
 meshgeometry.msh
 dev/Manifest.toml
 test/Manifest.toml
+test/qa/Manifest.toml
 docs/build/
 docs/site/
 docs/Manifest.toml

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FiniteVolumeMethod = "d4f04ab7-4f65-4d72-8a28-7087bc7f46f4"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -10,9 +9,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 FiniteVolumeMethod = {path = "../.."}
 
 [compat]
-Aqua = "0.7, 0.8"
-ExplicitImports = "1.15.0"
+Aqua = "0.8"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -7,23 +7,4 @@ run_qa(
     # deps live in test/Project.toml under the grouped-tests folder model, so the
     # root-vs-test consistency check does not apply here.
     aqua_kwargs = (; project_extras = false),
-    ei_kwargs = (;
-        # Other packages' non-public names accessed via `Module.name`. Each goes
-        # public as its base lib releases; ignore until then.
-        all_qualified_accesses_are_public = (;
-            ignore = (
-                :AutoSpecialize,                      # SciMLBase
-                :each_point, :each_point_index,       # DelaunayTriangulation
-                :get_centroid, :get_edge_midpoints,   # DelaunayTriangulation
-                :has_boundary_nodes, :has_ghost_triangles,  # DelaunayTriangulation
-                :has_vertex, :is_ghost_vertex,        # DelaunayTriangulation
-                :num_points, :num_segments,           # DelaunayTriangulation
-                :front, :tail,                        # Base
-                :init, :solve,                        # CommonSolve
-            ),
-        ),
-        # `solve` is CommonSolve's canonical (non-public) extension point that
-        # FiniteVolumeMethod imports and re-exports.
-        all_explicit_imports_are_public = (; ignore = (:solve,)),
-    ),
 )

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,14 +1,29 @@
-using FiniteVolumeMethod
-using Test
-using Aqua
-using ExplicitImports
+using SciMLTesting, FiniteVolumeMethod, Test
 
-@testset verbose = true "Aqua" begin
-    Aqua.test_all(FiniteVolumeMethod; ambiguities = false, project_extras = false) # don't care about julia < 1.2
-    Aqua.test_ambiguities(FiniteVolumeMethod) # don't pick up Base and Core...
-end
-
-@testset verbose = true "Explicit Imports" begin
-    @test check_no_implicit_imports(FiniteVolumeMethod) === nothing
-    @test check_no_stale_explicit_imports(FiniteVolumeMethod) === nothing
-end
+run_qa(
+    FiniteVolumeMethod;
+    explicit_imports = true,
+    # Root Project.toml carries only `Test` in [extras]/[targets]; the real test
+    # deps live in test/Project.toml under the grouped-tests folder model, so the
+    # root-vs-test consistency check does not apply here.
+    aqua_kwargs = (; project_extras = false),
+    ei_kwargs = (;
+        # Other packages' non-public names accessed via `Module.name`. Each goes
+        # public as its base lib releases; ignore until then.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :AutoSpecialize,                      # SciMLBase
+                :each_point, :each_point_index,       # DelaunayTriangulation
+                :get_centroid, :get_edge_midpoints,   # DelaunayTriangulation
+                :has_boundary_nodes, :has_ghost_triangles,  # DelaunayTriangulation
+                :has_vertex, :is_ghost_vertex,        # DelaunayTriangulation
+                :num_points, :num_segments,           # DelaunayTriangulation
+                :front, :tail,                        # Base
+                :init, :solve,                        # CommonSolve
+            ),
+        ),
+        # `solve` is CommonSolve's canonical (non-public) extension point that
+        # FiniteVolumeMethod imports and re-exports.
+        all_explicit_imports_are_public = (; ignore = (:solve,)),
+    ),
+)


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Brings this repo's QA onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled.

## What changed
- `test/qa/qa.jl`: hand-rolled `Aqua.test_all` + `Aqua.test_ambiguities` + two `ExplicitImports` checks → single `run_qa(FiniteVolumeMethod; explicit_imports = true, ...)`.
- The old `ambiguities = false` + separate `Aqua.test_ambiguities` split is collapsed: `run_qa`'s default `Aqua.test_all` runs (and passes) the ambiguities sub-check.
- Preserved the one genuine Aqua tweak `project_extras = false`: the root `Project.toml` carries only `Test` in `[extras]`/`[targets]`; the real test deps live in `test/Project.toml` under the grouped-tests folder model, so the root-vs-test consistency check does not apply.
- `test/qa/Project.toml`: `SciMLTesting` compat → `"1.6"`; dropped `ExplicitImports` (transitive via SciMLTesting); kept `Aqua` (the ambiguities child-process needs it a direct dep) and `SafeTestsets` (the `run_tests` `@safetestset` body wrapper does `using SafeTestsets` under the active QA sub-env).
- `.gitignore`: ignore the CI-generated `test/qa/Manifest.toml`.

## ExplicitImports findings (all 6 checks)
- `no_implicit_imports`, `no_stale_explicit_imports`, `all_explicit_imports_via_owners`, `all_qualified_accesses_via_owners` — **pass** as-is.
- `all_qualified_accesses_are_public` — failed on other packages' non-public names; **ignored** via `ei_kwargs` (each goes public as its base lib releases):
  - `AutoSpecialize` — SciMLBase
  - `each_point`, `each_point_index`, `get_centroid`, `get_edge_midpoints`, `has_boundary_nodes`, `has_ghost_triangles`, `has_vertex`, `is_ghost_vertex`, `num_points`, `num_segments` — DelaunayTriangulation
  - `front`, `tail` — Base
  - `init`, `solve` — CommonSolve
- `all_explicit_imports_are_public` — failed on `solve` (CommonSolve's canonical, non-public extension point that FVM imports and re-exports); **ignored**.

No `@test_broken` / `jet_broken` / `ei_broken` needed — every finding is a clean FIX (collapse) or IGNORE. No JET (the prior qa.jl had none).

## Verification
Run locally against released **SciMLTesting 1.6.0** (Pkg-resolved, no dev-from-branch) through the real `run_tests` harness with `GROUP=QA`:

```
Test Summary: | Pass  Total   Time
QA            |   16     16  27.7s
```

0 fail / 0 error / 0 broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)