### PR TITLE
Bump version to 1.2.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FiniteVolumeMethod"
 uuid = "d4f04ab7-4f65-4d72-8a28-7087bc7f46f4"
 authors = ["Daniel VandenHeuvel <danj.vandenheuvel@gmail.com>"]
-version = "1.2.2"
+version = "1.2.3"
 
 [deps]
 ChunkSplitters = "ae650224-84b6-46f8-82ea-d812ca08434e"


### PR DESCRIPTION
Automated patch version bump (1.2.2 -> 1.2.3) to release unreleased commits on `main` via JuliaRegistrator.