### PR TITLE
Enable rendered public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,6 +3,9 @@ using SciMLTesting, FiniteVolumeMethod, Test
 run_qa(
     FiniteVolumeMethod;
     explicit_imports = true,
+    # `solve` is reexported from CommonSolve; this package documents its
+    # methods but does not own the generic binding.
+    api_docs_kwargs = (; rendered = true, rendered_ignore = (:solve,)),
     # Root Project.toml carries only `Test` in [extras]/[targets]; the real test
     # deps live in test/Project.toml under the grouped-tests folder model, so the
     # root-vs-test consistency check does not apply here.


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enable SciMLTesting rendered public API docs QA with `api_docs_kwargs = (; rendered = true, ...)`.
- Add `solve` to `rendered_ignore` because the exported binding is owned by CommonSolve, while this package only defines methods for it.

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'` passed: Quality Assurance 16/16.
- `git diff --check` passed.
- Runic.jl v1.7.0 check passed on `test/qa/qa.jl` via a temporary local Julia environment.
- `CI=true timeout 3600 /home/crackauc/.juliaup/bin/julia +1.12 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'` exited 0. Existing docs warnings were observed from generated tutorial examples (`TRBDF2`/`KLUFactorization`/`MatrixOperator` imports and dependent undefined variables) and one Makie/DelaunayTriangulation plotting attribute warning.

## Notes
- Attempting the docs environment on Julia 1.10 failed during resolution because `docs/Project.toml` pins JET 0.11.x, whose Julia compat excludes 1.10. The requested SciMLTesting QA validation was run on Julia 1.10.