### PR TITLE
Pin downgrade CI to a hosted runner

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -18,4 +18,5 @@ jobs:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "lts"
+      os: "ubuntu-24.04"
     secrets: "inherit"


### PR DESCRIPTION
> Ignore this draft until it has been reviewed by @ChrisRackauckas.

## Summary

- pin the downgrade workflow to the reusable workflow's documented `ubuntu-24.04` runner input
- leave the downgrade resolver, dependency floors, and test coverage unchanged

## Why

The current `main` downgrade run ([29845314639](https://github.com/SciML/FiniteVolumeMethod.jl/actions/runs/29845314639)) completed resolution and build, then lost communication with its `self-hosted-4vcpu-8gb` runner while the test step was still active. There was no test or resolver failure in the uploaded metadata.

This is runner-specific rather than a repository regression:

- hosted run [29541435021](https://github.com/SciML/FiniteVolumeMethod.jl/actions/runs/29541435021) passed on commit `7738d76`, whose tree `e89ed738f45a8865b1fa74fb825af22010c80b74` is byte-identical to current `main` at `a9adb61`
- all 12 recent successful downgrade runs inspected used GitHub-hosted runners; 7 of 8 inspected failed self-hosted runs reported lost runner communication
- the exact current downgraded suite passed locally, but took 73m43.9s and reached about 6.4 GiB RSS during Gray-Scott

The centralized downgrade workflow exposes `os` as a public `workflow_call` input and documents `ubuntu-24.04` as the way to force GitHub-hosted execution.

## Validation

- Julia 1.10.11, `julia-downgrade-compat@fab1def`, exact current dependency graph: `Core | 1,288,226 passed / 1,288,226 total | 73m43.9s`
- `actionlint .github/workflows/Downgrade.yml`
- Runic 1.7 over every tracked `.jl` file
- `git diff --check`

## Investigation process

This was triggered by the fleet downgrade audit. I inspected the exact Actions job and annotations, reproduced the reusable downgrade action on a clean detached checkout of `a9adb61`, ran the repository's official grouped test harness with the same Julia and `Pkg.test` options, compared the failed runner with recent hosted and self-hosted history, and used the byte-identical hosted pass as the repository boundary. No tests were skipped, silenced, loosened, or removed.
