### PR TITLE
Allow intentional CommonSolve solve reexport in QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,10 +1,13 @@
 using SciMLTesting, FiniteVolumeMethod, Test
 
+@test SciMLTesting.public_reexports(FiniteVolumeMethod) == [:solve]
+
 run_qa(
     FiniteVolumeMethod;
     explicit_imports = true,
     # `solve` is reexported from CommonSolve; this package documents its
     # methods but does not own the generic binding.
+    reexports_allow = (:solve,),
     api_docs_kwargs = (; rendered = true, rendered_ignore = (:solve,)),
     # Root Project.toml carries only `Test` in [extras]/[targets]; the real test
     # deps live in test/Project.toml under the grouped-tests folder model, so the


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Assert that FiniteVolumeMethod's intentional public re-export set is exactly `[:solve]`.
- Allow that one CommonSolve-owned binding in SciMLTesting's default public re-export audit.
- Keep the re-export audit enabled so any additional dependency-owned public binding still fails QA.

## Root cause

SciMLTesting 2.4.0 enabled the public re-export audit by default. FiniteVolumeMethod intentionally imports and exports CommonSolve's `solve` generic and defines package-specific methods on it, so clean `main` began failing the new check even though #126 changed only the downgrade workflow.

The dependency boundary was verified locally on clean merge commit `e9fdb36edcdc7a8a528d47b19aaece5f5da2427e`:

- SciMLTesting 2.3.0: QA 18/18 passed.
- SciMLTesting 2.4.0: QA 18 passed, 1 failed; the only finding was `reexported == [:solve]`.

## Validation

- Julia 1.12.6, `GROUP=QA`, SciMLTesting 2.4.0, exact hosted test arguments: QA 20/20 passed.
- Julia 1.10.11 LTS, `GROUP=QA`, SciMLTesting 2.4.0, exact hosted test arguments: QA 18/18 passed.
- Runic.jl 1.7.0 `--check .`: exit 0.
- `git diff --check`: exit 0.

The first local LTS invocation stopped before running tests because an ignored Julia 1.12 manifest from the preceding local run was still present. I removed only that generated manifest and reran from a clean resolution state; the LTS QA result above is from the clean rerun.
